### PR TITLE
Update debian-jessie-install

### DIFF
--- a/debian/debian-jessie-install
+++ b/debian/debian-jessie-install
@@ -9,7 +9,7 @@ failed(){
 debian_install(){
   mkdir -p /tmp/newroot
   mount -t ext4 ${1} /tmp/newroot
-  debootstrap --arch=mipsel --include=vim,openssh-server,ntpdate,cron,locales,udev,ca-certificates,apt-transport-https,vlan jessie /tmp/newroot http://httpredir.debian.org/debian || failed debootstrap
+  debootstrap --arch=mipsel --include=vim,openssh-server,ntpdate,cron,locales,udev,ca-certificates,apt-transport-https,vlan jessie /tmp/newroot http://archive.debian.org/debian || failed debootstrap
 }
 
 debian_fix(){


### PR DESCRIPTION
Update `httpredir` to `archive` in download link (jessie for mipsel is not hosted on current mirros)